### PR TITLE
Set page titles explicitly

### DIFF
--- a/archive/harurobosemi2022.md
+++ b/archive/harurobosemi2022.md
@@ -1,7 +1,7 @@
 ---
+title: <a href="https://robosemi.github.io/">RoboSemi</a>
 description: 関西春ロボゼミ2022
 ---
-
 
 # 関西春ロボゼミ2022
 

--- a/archive/rsj2022.md
+++ b/archive/rsj2022.md
@@ -1,4 +1,5 @@
 ---
+title: <a href="https://robosemi.github.io/">RoboSemi</a>
 description: 第40回日本ロボット学会学術講演会（RSJ2022）
 ---
 

--- a/archive/rsj2023.md
+++ b/archive/rsj2023.md
@@ -1,4 +1,5 @@
 ---
+title: <a href="https://robosemi.github.io/">RoboSemi</a>
 description: RSJ2023 ロボット学コミュニティ醸成企画
 ---
 

--- a/seminar_list.md
+++ b/seminar_list.md
@@ -2,7 +2,7 @@
 description: Seminar List
 ---
 
-## ロボティクス関連の勉強会一覧
+# ロボティクス関連の勉強会一覧
 
 運営が知っているロボティクス関連の勉強会を集めてみました．  
 掲載されていない勉強会や掲載をご希望の勉強会があれば[GitHubのissue](https://github.com/robosemi/robosemi.github.io/issues)などで教えていただけると助かります．


### PR DESCRIPTION
ページタイトルの設定がおかしくなっているところを見つけましてよ．このままだとホームに戻れないページが出てしまいますわ．

よろしい例：

- https://robosemi.github.io/archive/history2020

よろしくない例：

- https://robosemi.github.io/archive/rsj2023
- https://robosemi.github.io/seminar_list

これらを鑑みるに，descriptionに全角文字が入っているページと，#が1つの見出しがないページが悪いようでしたわ．そこで，このおプルリクを試していただけませんこと？