### PR TITLE
アーカイブに2025/2026年の勉強会（第52〜56回）を追加

### DIFF
--- a/archive/history2025.md
+++ b/archive/history2025.md
@@ -46,6 +46,48 @@ description: Seminar History in 2025
 | 自動運転におけるVision-Language Action (VLA) modelに詳しくなりたい！と思った初学者が論文を一つ読んできたので紹介します | [Shin](https://connpass.com/user/ShintaroTomie/) | LT | 公開なし |
 | RoboCup Japan Open2025に参加してきました | [Hans_Robo](https://connpass.com/user/Hans_Robo/) | 通常発表（90分） | [資料（GoogleSlide）](https://docs.google.com/presentation/d/1pGS2MIIUnA4xz5JgeSRu7xLziHoXQo12BjkuUiC--hE/edit?usp=sharing) |
 
+## 第52回ロボティクス勉強会
+
+- 日時：2025/7/11 (金) 20:00~23:00
+- 参加者：45名
+- ツール：ZOOM
+- イベントページ：[connpass](https://robosemi.connpass.com/event/349745/)
+
+| タイトル | 発表者 | 発表枠 | 資料等 |
+| :--- | :--- | :--- | :--- |
+| ROS1 EOL後のROS1/ROS2＆Jetson開発環境構築・運用ノウハウ | [Tiryoh](https://connpass.com/user/Tiryoh/) | LT | [資料 (Zenn)](https://zenn.dev/tiryoh/articles/2025-07-20-ros2-cuda-jetson) |
+| 模倣学習をしてSO-101アームを動かしてみた | [yuto2000](https://connpass.com/user/yuto2000/) | LT |  |
+| 自動運転VLM初学者がCVPR2025の論文を読んできたので発表します | [Shin](https://connpass.com/user/ShintaroTomie/) | 通常発表 | 公開なし |
+| Livox Mid-360をROS 2で使いこなす | [dandelion1124](https://connpass.com/user/dandelion1124/) | 通常発表 | [資料 (Docswell)](https://www.docswell.com/s/dandelion1124/ZNJ68Q-2025-07-14-220903) |
+
+## 第53回ロボティクス勉強会
+
+- 日時：2025/9/19 (金) 20:00~23:00
+- 参加者：26名
+- ツール：ZOOM
+- イベントページ：[connpass](https://robosemi.connpass.com/event/361371/)
+
+| タイトル | 発表者 | 発表枠 | 資料等 |
+| :--- | :--- | :--- | :--- |
+| 3Dプリンタでロボット作るよ - ロボティクス向け材料編 | [shiba_8ro](https://connpass.com/user/shiba_8ro/) | LT | [資料 (SpeakerDeck)](https://speakerdeck.com/shiba_8ro/3dpurintaderobotutozuo-ruyo-number-5-robotutoxiang-ke3dpurintacai-liao) |
+| 無所属学会発表のすゝめ | [SatomiHanasaki](https://connpass.com/user/SatomiHanasaki/) | LT |  |
+| 高校生チームがRoboCup世界大会に参加してみた | [muramoto_koki](https://connpass.com/user/muramoto_koki/) | 通常発表 |  |
+| 自動運転におけるPlanningの評価指標RFS(Rater Feedback Score) | [Shin](https://connpass.com/user/ShintaroTomie/) | 通常発表 | 公開なし |
+
+## 第54回ロボティクス勉強会
+
+- 日時：2025/11/14 (金) 20:00~23:00
+- 参加者：25名
+- ツール：ZOOM
+- イベントページ：[connpass](https://robosemi.connpass.com/event/366873/)
+
+| タイトル | 発表者 | 発表枠 | 資料等 |
+| :--- | :--- | :--- | :--- |
+| 動くものづくりをもっと手軽にする「UGOKU」シリーズの紹介 | [AOKI Tomohiro](https://connpass.com/user/12tomo13a/) | LT | [資料 (Docswell)](https://www.docswell.com/s/12tomo13a/KEX27D-UGOKU_2025) |
+| 第54回ロボティクス勉強会　発表スライド | 龍 |  |  |
+| WRS2025出場完走とnステップで出来るWRS環境構築 | 龍 |  |  |
+| Hybrid A* Path Planning | 龍 |  |  |
+
 <!-- ## 第N回ロボティクス勉強会
 
 - 日時：2025/ (金) 20:00~23:00

--- a/archive/history2025.md
+++ b/archive/history2025.md
@@ -84,9 +84,9 @@ description: Seminar History in 2025
 | タイトル | 発表者 | 発表枠 | 資料等 |
 | :--- | :--- | :--- | :--- |
 | 動くものづくりをもっと手軽にする「UGOKU」シリーズの紹介 | [AOKI Tomohiro](https://connpass.com/user/12tomo13a/) | LT | [資料 (Docswell)](https://www.docswell.com/s/12tomo13a/KEX27D-UGOKU_2025) |
-| 第54回ロボティクス勉強会　発表スライド | 龍 |  |  |
-| WRS2025出場完走とnステップで出来るWRS環境構築 | 龍 |  |  |
-| Hybrid A* Path Planning | 龍 |  |  |
+|  | [takeofuture7](https://connpass.com/user/takeofuture7/) | LT |  |
+| WRS2025出場完走とnステップで出来るWRS環境構築 | [yoshiko_kulala](https://connpass.com/user/yoshiko_kulala/) | 通常発表 |  |
+| Hybrid A* Path Planning | 龍 | 通常発表 |  |
 
 <!-- ## 第N回ロボティクス勉強会
 

--- a/archive/history2025.md
+++ b/archive/history2025.md
@@ -70,7 +70,7 @@ description: Seminar History in 2025
 | タイトル | 発表者 | 発表枠 | 資料等 |
 | :--- | :--- | :--- | :--- |
 | 3Dプリンタでロボット作るよ - ロボティクス向け材料編 | [shiba_8ro](https://connpass.com/user/shiba_8ro/) | LT | [資料 (SpeakerDeck)](https://speakerdeck.com/shiba_8ro/3dpurintaderobotutozuo-ruyo-number-5-robotutoxiang-ke3dpurintacai-liao) |
-| 無所属学会発表のすゝめ | [SatomiHanasaki](https://connpass.com/user/SatomiHanasaki/) | LT |  |
+| 無所属学会発表のすゝめ | [SatomiHanasaki](https://connpass.com/user/SatomiHanasaki/) | LT | [資料 (Docswell)](https://www.docswell.com/s/atom-2003/ZX6DV7-2025-09-22-121124) |
 | 高校生チームがRoboCup世界大会に参加してみた | [muramoto_koki](https://connpass.com/user/muramoto_koki/) | 通常発表 |  |
 | 自動運転におけるPlanningの評価指標RFS(Rater Feedback Score) | [Shin](https://connpass.com/user/ShintaroTomie/) | 通常発表 | 公開なし |
 
@@ -84,9 +84,9 @@ description: Seminar History in 2025
 | タイトル | 発表者 | 発表枠 | 資料等 |
 | :--- | :--- | :--- | :--- |
 | 動くものづくりをもっと手軽にする「UGOKU」シリーズの紹介 | [AOKI Tomohiro](https://connpass.com/user/12tomo13a/) | LT | [資料 (Docswell)](https://www.docswell.com/s/12tomo13a/KEX27D-UGOKU_2025) |
-|  | [takeofuture7](https://connpass.com/user/takeofuture7/) | LT |  |
-| WRS2025出場完走とnステップで出来るWRS環境構築 | [yoshiko_kulala](https://connpass.com/user/yoshiko_kulala/) | 通常発表 |  |
-| Hybrid A* Path Planning | 龍 | 通常発表 |  |
+| コンピュータビジョンカンファレンス (ICCV2025)で発表されたロボティクス関連の論文を自分なりに理解して要約紹介RoboFactory: Exploring Embodies Agent Collaboration with Compositional Constraints | [takeofuture7](https://connpass.com/user/takeofuture7/) | LT | [資料 (SpeakerDeck)](https://speakerdeck.com/takeofuture/14-robosemidenofa-biao-zi-liao) |
+| WRS2025出場完走とnステップで出来るWRS環境構築 | [yoshiko_kulala](https://connpass.com/user/yoshiko_kulala/) | 通常発表 | [資料 (GoogleSlide)](https://docs.google.com/presentation/d/1jTq08u6lNY9yhz0kZLCggP1qWn_S8yTXqPgOSNyLNnM/edit?usp=sharing) |
+| Hybrid A* Path Planning | [龍](https://connpass.com/user/ryu_software/) | 通常発表 | [資料 (GoogleSlide)](https://docs.google.com/presentation/d/13J6iD_zXAfHuwmmGazeEqHfkUw51LrMus6jY5EBKhis/edit?usp=sharing) |
 
 <!-- ## 第N回ロボティクス勉強会
 

--- a/archive/history2026.md
+++ b/archive/history2026.md
@@ -1,0 +1,51 @@
+---
+description: Seminar History in 2026
+---
+
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico?">
+
+# 2026年の記録
+
+## 第55回ロボティクス勉強会
+
+- 日時：2026/1/23 (金) 20:00~23:00
+- 参加者：22名
+- ツール：ZOOM
+- イベントページ：[connpass](https://robosemi.connpass.com/event/376604/)
+
+| タイトル | 発表者 | 発表枠 | 資料等 |
+| :--- | :--- | :--- | :--- |
+| （仮）Sim2Realの手順調べてみた。or 旬のロボティクス関連の論文サーベイまとめ | [takeofuture7](https://connpass.com/user/takeofuture7/) | LT | [資料 (SpeakerDeck)](https://speakerdeck.com/takeofuture/rosatoiullmshi-tutarosezientowoomotiyanishi-zhuang-sitemitahua) |
+| Unity製ROS 2シミュレータの紹介 | Masaaki Hijikata | LT |  |
+| LiDARSemi#5 カメラでLiDARを撮影するとセンサが焼ける現象について(仮) | [Hans_Robo](https://connpass.com/user/Hans_Robo/) | 通常発表 |  |
+| Alpamayo-1: NVIDIAが開発したVLM自動運転モデルの中身に迫る | [Shin](https://connpass.com/user/ShintaroTomie/) | 通常発表 | 公開なし |
+
+## 第56回ロボティクス勉強会
+
+- 日時：2026/5/15 (金) 20:00~23:00
+- 参加者：2名
+- ツール：ZOOM
+- イベントページ：[connpass](https://robosemi.connpass.com/event/383476/)
+
+| タイトル | 発表者 | 発表枠 | 資料等 |
+| :--- | :--- | :--- | :--- |
+|  |  | LT |  |
+|  |  | LT |  |
+|  |  | 通常発表 |  |
+|  |  | 通常発表 |  |
+
+<!-- ## 第N回ロボティクス勉強会
+
+- 日時：2026/ (金) 20:00~23:00
+- 参加者：N名
+- ツール：ZOOM
+- イベントページ：[connpass](URL)
+
+| タイトル | 発表者 | 発表枠 | 資料等 |
+| :--- | :--- | :--- | :--- |
+|  | [name](https://connpass.com/user/name/) | LT | [資料](url) |
+|  | [name](https://connpass.com/user/name/) | LT | [資料](url) |
+|  | [name](https://connpass.com/user/name/) | 通常発表（N分） | [資料](url) |
+|  | [name](https://connpass.com/user/name/) | 通常発表（N分） | [資料](url) | -->
+- - -
+[Back](../index)

--- a/archive/history2026.md
+++ b/archive/history2026.md
@@ -17,7 +17,7 @@ description: Seminar History in 2026
 | :--- | :--- | :--- | :--- |
 | （仮）Sim2Realの手順調べてみた。or 旬のロボティクス関連の論文サーベイまとめ | [takeofuture7](https://connpass.com/user/takeofuture7/) | LT | [資料 (SpeakerDeck)](https://speakerdeck.com/takeofuture/rosatoiullmshi-tutarosezientowoomotiyanishi-zhuang-sitemitahua) |
 | Unity製ROS 2シミュレータの紹介 | Masaaki Hijikata | LT |  |
-| LiDARSemi#5 カメラでLiDARを撮影するとセンサが焼ける現象について(仮) | [Hans_Robo](https://connpass.com/user/Hans_Robo/) | 通常発表 |  |
+| LiDARSemi#5 カメラでLiDARを撮影するとセンサが焼ける現象について(仮) | [Hans_Robo](https://connpass.com/user/Hans_Robo/) | 通常発表 | [資料 (GoogleSlide)](https://docs.google.com/presentation/d/1h-bD9hrftQ0QbHajO_Ke0oiDSsT-B9M2KmZk3oRWZ_g/edit?usp=sharing) |
 | Alpamayo-1: NVIDIAが開発したVLM自動運転モデルの中身に迫る | [Shin](https://connpass.com/user/ShintaroTomie/) | 通常発表 | 公開なし |
 
 ## 第56回ロボティクス勉強会

--- a/archive/history2026.md
+++ b/archive/history2026.md
@@ -24,16 +24,15 @@ description: Seminar History in 2026
 ## 第56回ロボティクス勉強会
 
 - 日時：2026/5/15 (金) 20:00~23:00
-- 参加者：2名
+- 参加者：20名
 - ツール：ZOOM
 - イベントページ：[connpass](https://robosemi.connpass.com/event/383476/)
 
 | タイトル | 発表者 | 発表枠 | 資料等 |
 | :--- | :--- | :--- | :--- |
-|  |  | LT |  |
-|  |  | LT |  |
-|  |  | 通常発表 |  |
-|  |  | 通常発表 |  |
+|  | [takeofuture](https://connpass.com/user/takeofuture7/) | LT | [資料 (SpeakerDeck)](https://speakerdeck.com/takeofuture/forklift-goal-condition-reinforcement-learning-by-gazebo-plus-ros2-topic) |
+| 「JAXAベンチャー”emblem”によるジェットパック型飛行装置の開発 | [Daichi-Wada](https://connpass.com/user/Daichi-Wada/) | LT |  |
+| LiDARを使わずにTPS風遠隔操縦画面を生成してみた | [Masaaki Hijikata](https://connpass.com/user/hijimasa/) | 通常発表 | [資料 (GoogleSlide)](https://docs.google.com/presentation/d/1W1Sjhj9JOIzJpNT3hViI9K6l69NOuW7S/edit?usp=sharing&ouid=103201946606274363939&rtpof=true&sd=true) |
 
 <!-- ## 第N回ロボティクス勉強会
 

--- a/archive/history2026.md
+++ b/archive/history2026.md
@@ -15,8 +15,9 @@ description: Seminar History in 2026
 
 | タイトル | 発表者 | 発表枠 | 資料等 |
 | :--- | :--- | :--- | :--- |
-| （仮）Sim2Realの手順調べてみた。or 旬のロボティクス関連の論文サーベイまとめ | [takeofuture7](https://connpass.com/user/takeofuture7/) | LT | [資料 (SpeakerDeck)](https://speakerdeck.com/takeofuture/rosatoiullmshi-tutarosezientowoomotiyanishi-zhuang-sitemitahua) |
-| Unity製ROS 2シミュレータの紹介 | Masaaki Hijikata | LT |  |
+| ROSAというLLM使ったROSエージェントをおもちゃに実装してみた話
+ | [takeofuture7](https://connpass.com/user/takeofuture7/) | LT | [資料 (SpeakerDeck)](https://speakerdeck.com/takeofuture/rosatoiullmshi-tutarosezientowoomotiyanishi-zhuang-sitemitahua) |
+| Unity製ROS 2シミュレータの紹介 | [Masaaki Hijikata](https://connpass.com/user/hijimasa/) | LT | [資料 (GoogleSlide)](https://docs.google.com/presentation/d/10cgCjAEZoM54I2WYWG2ElWb-TR8pQ16N/edit?usp=sharing&ouid=103201946606274363939&rtpof=true&sd=true) |
 | LiDARSemi#5 カメラでLiDARを撮影するとセンサが焼ける現象について(仮) | [Hans_Robo](https://connpass.com/user/Hans_Robo/) | 通常発表 | [資料 (GoogleSlide)](https://docs.google.com/presentation/d/1h-bD9hrftQ0QbHajO_Ke0oiDSsT-B9M2KmZk3oRWZ_g/edit?usp=sharing) |
 | Alpamayo-1: NVIDIAが開発したVLM自動運転モデルの中身に迫る | [Shin](https://connpass.com/user/ShintaroTomie/) | 通常発表 | 公開なし |
 

--- a/archive/history_all.md
+++ b/archive/history_all.md
@@ -9,7 +9,7 @@ description: 全勉強会アーカイブ（第0回〜最新）
 このページは検索性向上のため、全ての勉強会記録を1ページにまとめたものです。
 
 **年ごとの記録:**
-[2020年](history2020) | [2021年](history2021) | [2022年](history2022) | [2023年](history2023) | [2024年](history2024) | [2025年](history2025)
+[2020年](history2020) | [2021年](history2021) | [2022年](history2022) | [2023年](history2023) | [2024年](history2024) | [2025年](history2025) | [2026年](history2026)
 
 ---
 
@@ -772,9 +772,97 @@ description: 全勉強会アーカイブ（第0回〜最新）
 | 自動運転におけるVision-Language Action (VLA) modelに詳しくなりたい！と思った初学者が論文を一つ読んできたので紹介します | [Shin](https://connpass.com/user/ShintaroTomie/) | LT | 公開なし |
 | RoboCup Japan Open2025に参加してきました | [Hans_Robo](https://connpass.com/user/Hans_Robo/) | 通常発表（90分） | [資料（GoogleSlide）](https://docs.google.com/presentation/d/1pGS2MIIUnA4xz5JgeSRu7xLziHoXQo12BjkuUiC--hE/edit?usp=sharing) |
 
+## 第52回ロボティクス勉強会
+
+- 日時：2025/7/11 (金) 20:00~23:00
+- 参加者：45名
+- ツール：ZOOM
+- イベントページ：[connpass](https://robosemi.connpass.com/event/349745/)
+
+| タイトル | 発表者 | 発表枠 | 資料等 |
+| :--- | :--- | :--- | :--- |
+| ROS1 EOL後のROS1/ROS2＆Jetson開発環境構築・運用ノウハウ | [Tiryoh](https://connpass.com/user/Tiryoh/) | LT | [資料 (Zenn)](https://zenn.dev/tiryoh/articles/2025-07-20-ros2-cuda-jetson) |
+| 模倣学習をしてSO-101アームを動かしてみた | [yuto2000](https://connpass.com/user/yuto2000/) | LT |  |
+| 自動運転VLM初学者がCVPR2025の論文を読んできたので発表します | [Shin](https://connpass.com/user/ShintaroTomie/) | 通常発表 | 公開なし |
+| Livox Mid-360をROS 2で使いこなす | [dandelion1124](https://connpass.com/user/dandelion1124/) | 通常発表 | [資料 (Docswell)](https://www.docswell.com/s/dandelion1124/ZNJ68Q-2025-07-14-220903) |
+
+## 第53回ロボティクス勉強会
+
+- 日時：2025/9/19 (金) 20:00~23:00
+- 参加者：26名
+- ツール：ZOOM
+- イベントページ：[connpass](https://robosemi.connpass.com/event/361371/)
+
+| タイトル | 発表者 | 発表枠 | 資料等 |
+| :--- | :--- | :--- | :--- |
+| 3Dプリンタでロボット作るよ - ロボティクス向け材料編 | [shiba_8ro](https://connpass.com/user/shiba_8ro/) | LT | [資料 (SpeakerDeck)](https://speakerdeck.com/shiba_8ro/3dpurintaderobotutozuo-ruyo-number-5-robotutoxiang-ke3dpurintacai-liao) |
+| 無所属学会発表のすゝめ | [SatomiHanasaki](https://connpass.com/user/SatomiHanasaki/) | LT |  |
+| 高校生チームがRoboCup世界大会に参加してみた | [muramoto_koki](https://connpass.com/user/muramoto_koki/) | 通常発表 |  |
+| 自動運転におけるPlanningの評価指標RFS(Rater Feedback Score) | [Shin](https://connpass.com/user/ShintaroTomie/) | 通常発表 | 公開なし |
+
+## 第54回ロボティクス勉強会
+
+- 日時：2025/11/14 (金) 20:00~23:00
+- 参加者：25名
+- ツール：ZOOM
+- イベントページ：[connpass](https://robosemi.connpass.com/event/366873/)
+
+| タイトル | 発表者 | 発表枠 | 資料等 |
+| :--- | :--- | :--- | :--- |
+| 動くものづくりをもっと手軽にする「UGOKU」シリーズの紹介 | [AOKI Tomohiro](https://connpass.com/user/12tomo13a/) | LT | [資料 (Docswell)](https://www.docswell.com/s/12tomo13a/KEX27D-UGOKU_2025) |
+| 第54回ロボティクス勉強会　発表スライド | 龍 |  |  |
+| WRS2025出場完走とnステップで出来るWRS環境構築 | 龍 |  |  |
+| Hybrid A* Path Planning | 龍 |  |  |
+
 <!-- ## 第N回ロボティクス勉強会
 
 - 日時：2025/ (金) 20:00~23:00
+- 参加者：N名
+- ツール：ZOOM
+- イベントページ：[connpass](URL)
+
+| タイトル | 発表者 | 発表枠 | 資料等 |
+| :--- | :--- | :--- | :--- |
+|  | [name](https://connpass.com/user/name/) | LT | [資料](url) |
+|  | [name](https://connpass.com/user/name/) | LT | [資料](url) |
+|  | [name](https://connpass.com/user/name/) | 通常発表（N分） | [資料](url) |
+|  | [name](https://connpass.com/user/name/) | 通常発表（N分） | [資料](url) | -->
+
+---
+
+# 2026年の記録
+
+## 第55回ロボティクス勉強会
+
+- 日時：2026/1/23 (金) 20:00~23:00
+- 参加者：22名
+- ツール：ZOOM
+- イベントページ：[connpass](https://robosemi.connpass.com/event/376604/)
+
+| タイトル | 発表者 | 発表枠 | 資料等 |
+| :--- | :--- | :--- | :--- |
+| （仮）Sim2Realの手順調べてみた。or 旬のロボティクス関連の論文サーベイまとめ | [takeofuture7](https://connpass.com/user/takeofuture7/) | LT | [資料 (SpeakerDeck)](https://speakerdeck.com/takeofuture/rosatoiullmshi-tutarosezientowoomotiyanishi-zhuang-sitemitahua) |
+| Unity製ROS 2シミュレータの紹介 | Masaaki Hijikata | LT |  |
+| LiDARSemi#5 カメラでLiDARを撮影するとセンサが焼ける現象について(仮) | [Hans_Robo](https://connpass.com/user/Hans_Robo/) | 通常発表 |  |
+| Alpamayo-1: NVIDIAが開発したVLM自動運転モデルの中身に迫る | [Shin](https://connpass.com/user/ShintaroTomie/) | 通常発表 | 公開なし |
+
+## 第56回ロボティクス勉強会
+
+- 日時：2026/5/15 (金) 20:00~23:00
+- 参加者：2名
+- ツール：ZOOM
+- イベントページ：[connpass](https://robosemi.connpass.com/event/383476/)
+
+| タイトル | 発表者 | 発表枠 | 資料等 |
+| :--- | :--- | :--- | :--- |
+|  |  | LT |  |
+|  |  | LT |  |
+|  |  | 通常発表 |  |
+|  |  | 通常発表 |  |
+
+<!-- ## 第N回ロボティクス勉強会
+
+- 日時：2026/ (金) 20:00~23:00
 - 参加者：N名
 - ツール：ZOOM
 - イベントページ：[connpass](URL)

--- a/archive/history_all.md
+++ b/archive/history_all.md
@@ -810,9 +810,9 @@ description: 全勉強会アーカイブ（第0回〜最新）
 | タイトル | 発表者 | 発表枠 | 資料等 |
 | :--- | :--- | :--- | :--- |
 | 動くものづくりをもっと手軽にする「UGOKU」シリーズの紹介 | [AOKI Tomohiro](https://connpass.com/user/12tomo13a/) | LT | [資料 (Docswell)](https://www.docswell.com/s/12tomo13a/KEX27D-UGOKU_2025) |
-| 第54回ロボティクス勉強会　発表スライド | 龍 |  |  |
-| WRS2025出場完走とnステップで出来るWRS環境構築 | 龍 |  |  |
-| Hybrid A* Path Planning | 龍 |  |  |
+|  | [takeofuture7](https://connpass.com/user/takeofuture7/) | LT |  |
+| WRS2025出場完走とnステップで出来るWRS環境構築 | [yoshiko_kulala](https://connpass.com/user/yoshiko_kulala/) | 通常発表 |  |
+| Hybrid A* Path Planning | 龍 | 通常発表 |  |
 
 <!-- ## 第N回ロボティクス勉強会
 

--- a/archive/history_all.md
+++ b/archive/history_all.md
@@ -850,16 +850,15 @@ description: 全勉強会アーカイブ（第0回〜最新）
 ## 第56回ロボティクス勉強会
 
 - 日時：2026/5/15 (金) 20:00~23:00
-- 参加者：2名
+- 参加者：20名
 - ツール：ZOOM
 - イベントページ：[connpass](https://robosemi.connpass.com/event/383476/)
 
 | タイトル | 発表者 | 発表枠 | 資料等 |
 | :--- | :--- | :--- | :--- |
-|  |  | LT |  |
-|  |  | LT |  |
-|  |  | 通常発表 |  |
-|  |  | 通常発表 |  |
+|  | [takeofuture](https://connpass.com/user/takeofuture7/) | LT | [資料 (SpeakerDeck)](https://speakerdeck.com/takeofuture/forklift-goal-condition-reinforcement-learning-by-gazebo-plus-ros2-topic) |
+| 「JAXAベンチャー”emblem”によるジェットパック型飛行装置の開発 | [Daichi-Wada](https://connpass.com/user/Daichi-Wada/) | LT |  |
+| LiDARを使わずにTPS風遠隔操縦画面を生成してみた | [Masaaki Hijikata](https://connpass.com/user/hijimasa/) | 通常発表 | [資料 (GoogleSlide)](https://docs.google.com/presentation/d/1W1Sjhj9JOIzJpNT3hViI9K6l69NOuW7S/edit?usp=sharing&ouid=103201946606274363939&rtpof=true&sd=true) |
 
 <!-- ## 第N回ロボティクス勉強会
 

--- a/archive/history_all.md
+++ b/archive/history_all.md
@@ -843,7 +843,7 @@ description: 全勉強会アーカイブ（第0回〜最新）
 | :--- | :--- | :--- | :--- |
 | （仮）Sim2Realの手順調べてみた。or 旬のロボティクス関連の論文サーベイまとめ | [takeofuture7](https://connpass.com/user/takeofuture7/) | LT | [資料 (SpeakerDeck)](https://speakerdeck.com/takeofuture/rosatoiullmshi-tutarosezientowoomotiyanishi-zhuang-sitemitahua) |
 | Unity製ROS 2シミュレータの紹介 | Masaaki Hijikata | LT |  |
-| LiDARSemi#5 カメラでLiDARを撮影するとセンサが焼ける現象について(仮) | [Hans_Robo](https://connpass.com/user/Hans_Robo/) | 通常発表 |  |
+| LiDARSemi#5 カメラでLiDARを撮影するとセンサが焼ける現象について(仮) | [Hans_Robo](https://connpass.com/user/Hans_Robo/) | 通常発表 | [資料 (GoogleSlide)](https://docs.google.com/presentation/d/1h-bD9hrftQ0QbHajO_Ke0oiDSsT-B9M2KmZk3oRWZ_g/edit?usp=sharing) |
 | Alpamayo-1: NVIDIAが開発したVLM自動運転モデルの中身に迫る | [Shin](https://connpass.com/user/ShintaroTomie/) | 通常発表 | 公開なし |
 
 ## 第56回ロボティクス勉強会

--- a/archive/history_all.md
+++ b/archive/history_all.md
@@ -796,7 +796,7 @@ description: 全勉強会アーカイブ（第0回〜最新）
 | タイトル | 発表者 | 発表枠 | 資料等 |
 | :--- | :--- | :--- | :--- |
 | 3Dプリンタでロボット作るよ - ロボティクス向け材料編 | [shiba_8ro](https://connpass.com/user/shiba_8ro/) | LT | [資料 (SpeakerDeck)](https://speakerdeck.com/shiba_8ro/3dpurintaderobotutozuo-ruyo-number-5-robotutoxiang-ke3dpurintacai-liao) |
-| 無所属学会発表のすゝめ | [SatomiHanasaki](https://connpass.com/user/SatomiHanasaki/) | LT |  |
+| 無所属学会発表のすゝめ | [SatomiHanasaki](https://connpass.com/user/SatomiHanasaki/) | LT | [資料 (Docswell)](https://www.docswell.com/s/atom-2003/ZX6DV7-2025-09-22-121124) |
 | 高校生チームがRoboCup世界大会に参加してみた | [muramoto_koki](https://connpass.com/user/muramoto_koki/) | 通常発表 |  |
 | 自動運転におけるPlanningの評価指標RFS(Rater Feedback Score) | [Shin](https://connpass.com/user/ShintaroTomie/) | 通常発表 | 公開なし |
 
@@ -810,9 +810,9 @@ description: 全勉強会アーカイブ（第0回〜最新）
 | タイトル | 発表者 | 発表枠 | 資料等 |
 | :--- | :--- | :--- | :--- |
 | 動くものづくりをもっと手軽にする「UGOKU」シリーズの紹介 | [AOKI Tomohiro](https://connpass.com/user/12tomo13a/) | LT | [資料 (Docswell)](https://www.docswell.com/s/12tomo13a/KEX27D-UGOKU_2025) |
-|  | [takeofuture7](https://connpass.com/user/takeofuture7/) | LT |  |
-| WRS2025出場完走とnステップで出来るWRS環境構築 | [yoshiko_kulala](https://connpass.com/user/yoshiko_kulala/) | 通常発表 |  |
-| Hybrid A* Path Planning | 龍 | 通常発表 |  |
+| コンピュータビジョンカンファレンス (ICCV2025)で発表されたロボティクス関連の論文を自分なりに理解して要約紹介RoboFactory: Exploring Embodies Agent Collaboration with Compositional Constraints | [takeofuture7](https://connpass.com/user/takeofuture7/) | LT | [資料 (SpeakerDeck)](https://speakerdeck.com/takeofuture/14-robosemidenofa-biao-zi-liao) |
+| WRS2025出場完走とnステップで出来るWRS環境構築 | [yoshiko_kulala](https://connpass.com/user/yoshiko_kulala/) | 通常発表 | [資料 (GoogleSlide)](https://docs.google.com/presentation/d/1jTq08u6lNY9yhz0kZLCggP1qWn_S8yTXqPgOSNyLNnM/edit?usp=sharing) |
+| Hybrid A* Path Planning | [龍](https://connpass.com/user/ryu_software/) | 通常発表 | [資料 (GoogleSlide)](https://docs.google.com/presentation/d/13J6iD_zXAfHuwmmGazeEqHfkUw51LrMus6jY5EBKhis/edit?usp=sharing) |
 
 <!-- ## 第N回ロボティクス勉強会
 
@@ -841,8 +841,9 @@ description: 全勉強会アーカイブ（第0回〜最新）
 
 | タイトル | 発表者 | 発表枠 | 資料等 |
 | :--- | :--- | :--- | :--- |
-| （仮）Sim2Realの手順調べてみた。or 旬のロボティクス関連の論文サーベイまとめ | [takeofuture7](https://connpass.com/user/takeofuture7/) | LT | [資料 (SpeakerDeck)](https://speakerdeck.com/takeofuture/rosatoiullmshi-tutarosezientowoomotiyanishi-zhuang-sitemitahua) |
-| Unity製ROS 2シミュレータの紹介 | Masaaki Hijikata | LT |  |
+| ROSAというLLM使ったROSエージェントをおもちゃに実装してみた話
+ | [takeofuture7](https://connpass.com/user/takeofuture7/) | LT | [資料 (SpeakerDeck)](https://speakerdeck.com/takeofuture/rosatoiullmshi-tutarosezientowoomotiyanishi-zhuang-sitemitahua) |
+| Unity製ROS 2シミュレータの紹介 | [Masaaki Hijikata](https://connpass.com/user/hijimasa/) | LT | [資料 (GoogleSlide)](https://docs.google.com/presentation/d/10cgCjAEZoM54I2WYWG2ElWb-TR8pQ16N/edit?usp=sharing&ouid=103201946606274363939&rtpof=true&sd=true) |
 | LiDARSemi#5 カメラでLiDARを撮影するとセンサが焼ける現象について(仮) | [Hans_Robo](https://connpass.com/user/Hans_Robo/) | 通常発表 | [資料 (GoogleSlide)](https://docs.google.com/presentation/d/1h-bD9hrftQ0QbHajO_Ke0oiDSsT-B9M2KmZk3oRWZ_g/edit?usp=sharing) |
 | Alpamayo-1: NVIDIAが開発したVLM自動運転モデルの中身に迫る | [Shin](https://connpass.com/user/ShintaroTomie/) | 通常発表 | 公開なし |
 

--- a/index.md
+++ b/index.md
@@ -69,7 +69,8 @@ layout: default
 - [2022年の記録（第20回〜第31回）](archive/history2022)
 - [2023年の記録（第32回〜第42回）](archive/history2023)
 - [2024年の記録（第43回〜第48回）](archive/history2024)
-- [2025年の記録（第49回〜）](archive/history2025)
+- [2025年の記録（第49回〜第54回）](archive/history2025)
+- [2026年の記録（第55回〜）](archive/history2026)
 
 ## 主催
 

--- a/scripts/generate-combined-archive.sh
+++ b/scripts/generate-combined-archive.sh
@@ -15,14 +15,14 @@ description: 全勉強会アーカイブ（第0回〜最新）
 このページは検索性向上のため、全ての勉強会記録を1ページにまとめたものです。
 
 **年ごとの記録:**
-[2020年](history2020) | [2021年](history2021) | [2022年](history2022) | [2023年](history2023) | [2024年](history2024) | [2025年](history2025)
+[2020年](history2020) | [2021年](history2021) | [2022年](history2022) | [2023年](history2023) | [2024年](history2024) | [2025年](history2025) | [2026年](history2026)
 
 ---
 
 EOF
 
 # 古い年から新しい年へ順に結合
-for year in 2020 2021 2022 2023 2024 2025; do
+for year in 2020 2021 2022 2023 2024 2025 2026; do
   file="archive/history${year}.md"
   if [ -f "$file" ]; then
     # frontmatter、linkタグ、Backリンク、区切り線を除去


### PR DESCRIPTION
### Motivation
- Connpass のイベント情報（ID: `349745`, `361371`, `366873`, `376604`, `383476`）をサイトのアーカイブに反映するため。
- 年単位のアーカイブ一覧と全アーカイブ生成スクリプトを最新年に対応させるため。

### Description
- `archive/history2025.md` に第52回〜第54回（イベントID: `349745`, `361371`, `366873`）の開催情報と発表一覧を追加し、判明している資料リンクのみ記載して不明な箇所は空欄としました。 
- `archive/history2026.md` を新規作成し、第55回・第56回（イベントID: `376604`, `383476`）の予定情報を追加して未確認の発表は空欄にしています。 
- トップページ `index.md` のアーカイブリンク表記を `第54回` までに更新し、`2026年` のリンクを追加しました。 
- `scripts/generate-combined-archive.sh` を 2026 年対応に更新し、`archive/history_all.md` を再生成して反映しました。 
- 軽微な表記修正（例: `RFS(Rater Feedback Socre)` → `RFS(Rater Feedback Score)`、一部名前表記の簡素化）を行いました。

### Testing
- `git diff --check` を実行して差分に問題がないことを確認しました（成功）。
- `bash scripts/generate-combined-archive.sh` を実行し、`archive/history_all.md` のハッシュ比較による再生成の可搬性チェックを行って期待どおりの結果を確認しました（成功）。
- `bundle exec jekyll build` はローカルで実行できず確認できませんでした（`jekyll` 未インストール）。
- `bundle install` は `rubygems.org` へのアクセスで `403 Forbidden` が返り依存解決できなかったため実行不能でした（失敗）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07228de7b88330825cb068b5e5fddc)